### PR TITLE
Add basic Jest test for contact form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/tests/contactForm.test.js
+++ b/tests/contactForm.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+// JSDOM will automatically create a document for us
+document.body.innerHTML = `
+  <form id="contact-form"></form>
+  <div id="success-message" style="display:none"></div>
+`;
+
+// Require the script after setting up DOM so it can attach event listener
+require('../scripts/script.js');
+
+const form = document.getElementById('contact-form');
+const successMessage = document.getElementById('success-message');
+
+test('submitting the form toggles success message', () => {
+  // Ensure initial state
+  expect(successMessage.style.display).toBe('none');
+
+  // Dispatch submit event
+  const event = new Event('submit');
+  form.dispatchEvent(event);
+
+  // After submit, success message should be visible
+  expect(successMessage.style.display).toBe('block');
+});

--- a/tests/contactForm.test.js
+++ b/tests/contactForm.test.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const path = require('path');
+/** @jest-environment jsdom */
 
 // JSDOM will automatically create a document for us
 document.body.innerHTML = `

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};


### PR DESCRIPTION
## Summary
- add Jest setup under `tests/`
- create a DOM test for the contact form
- define `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842406efb68832783bb643ca735164c